### PR TITLE
分类左侧列表抽离为公共组件，完善Header公共组件，使其适配所有页面场景

### DIFF
--- a/entry/src/main/ets/common/utils/utils.ets
+++ b/entry/src/main/ets/common/utils/utils.ets
@@ -1,7 +1,7 @@
 import { unifiedDataChannel } from '@kit.ArkData';
 import { pasteboard } from '@kit.BasicServicesKit'
-import { showMessage } from '../../componets/common/promptShow';
 
+// 获取粘贴类型
 export const getPasteDataSync = () => {
   try {
     const data = pasteboard.getSystemPasteboard().getUnifiedDataSync()
@@ -20,6 +20,7 @@ export const isNetworkUrl = (url: string) => {
   url.startsWith('https://');
 }
 
+// 延迟多少毫秒
 export const sleep = (duration: number = 1000): Promise<void> => {
   return new Promise((resolve) => {
     setTimeout(() => {

--- a/entry/src/main/ets/componets/common/ClassifyList.ets
+++ b/entry/src/main/ets/componets/common/ClassifyList.ets
@@ -1,0 +1,85 @@
+/**
+ * @author Andy
+ * @datetime 2024/7/6 01:06
+ * @className: ClassifyList
+ * 分类左侧列表，支持是否开启角标
+ */
+import { GroupList } from '../dataList/BookSource'
+
+@Component
+export default struct ClassifyList {
+  @Link currentIndex: number
+  @Prop classifyList: GroupList[] | string[] = []
+  @Prop isBadge: boolean = false
+  clickAction: Function = (_index: number) => {}
+  scroller?: Scroller = undefined
+
+  build() {
+    List({ scroller: this.scroller }) {
+      ForEach(this.classifyList, (item: GroupList | string, index: number) => {
+        ListItem() {
+          Stack({ alignContent: Alignment.TopStart }) {
+            Column() {
+              Stack({ alignContent: Alignment.TopEnd }) {
+                Text(typeof item === 'string' ? item : item.title)
+                  .height('48vp')
+                  .textAlign(TextAlign.Center)
+                  .fontWeight(this.currentIndex === index ? FontWeight.Bold : FontWeight.Normal)
+
+                if (this.isBadge && typeof item !== 'string') {
+                  Column() {
+                    Text(item.list.length.toString())
+                      .fontSize(10)
+                      .fontWeight(500)
+                      .fontColor(Color.White)
+                      .textAlign(TextAlign.Center)
+                  }
+                  .height(16)
+                  .position({
+                    right: -10
+                  })
+                  .justifyContent(FlexAlign.Center)
+                  .padding({ left: 4, right: 4 })
+                  .borderRadius(20)
+                  .backgroundColor(0xEF4444)
+                }
+              }
+            }
+            .width('100%')
+            .alignItems(HorizontalAlign.Center)
+            .backgroundColor(this.currentIndex === index ? 0xF5F5F5 : Color.White)
+            .borderRadius({
+              topRight: this.currentIndex + 1 === index ? 12 : 0,
+              bottomRight: this.currentIndex - 1 === index || this.classifyList.length === index + 1 ? 12 : 0
+            })
+            .animation({
+              duration: 100,
+              curve: Curve.Linear
+            })
+            .onClick(() => {
+              this.clickAction(index)
+            })
+
+            if (this.currentIndex === index) {
+              Row()
+                .width(3)
+                .height(16)
+                .backgroundColor('#FF6600')
+                .borderRadius(12)
+                .position({
+                  top: 16
+                })
+            }
+          }
+        }
+      })
+    }
+    .height('100%')
+    .width('100%')
+    .scrollBar(BarState.Off)
+    .borderRadius({
+      topRight: 12,
+      bottomRight: 12
+    })
+  }
+}

--- a/entry/src/main/ets/componets/common/Header.ets
+++ b/entry/src/main/ets/componets/common/Header.ets
@@ -1,37 +1,59 @@
+/**
+ * @author Andy
+ * @datetime 2024/7/6 01:36
+ * @className: Header
+ * 公共头部组件，默认使用返回按钮，标题，右侧下拉框的等公共能力
+ * 自定义左侧/中间/右侧的内容，内部已设置顶部安全区
+ * 右侧的下拉菜单的图标可通过rightIcon传入更改
+ * 设置自定义区域后，相应的默认区域失效
+ */
 import { router } from '@kit.ArkUI'
 import { IconTitleVo } from '../../componetsmodel/IconTitleVo'
 import dialogTitleFuction from './dialogTitleFuction'
 
 @Component
 export default struct Header {
-  @Builder
-  titleBuilder() {
-  }
-
+  @Builder leftBuilder() {}
+  // 自定义左侧区域
+  @BuilderParam customLeftBuilder: () => void = this.leftBuilder
+  @Builder titleBuilder() {}
+  // 自定义中间区域
   @BuilderParam customTitleBuilder: () => void = this.titleBuilder
+  @Builder rightBuilder() {}
+  // 自定义右侧区域
+  @BuilderParam customRightBuilder: () => void = this.rightBuilder
   @StorageLink('topRectHeight') topRectHeight: number = 0
+
+  paddingTop: number = 0
   title: string = ''
   dialogRightData: IconTitleVo[] = []
-  dialogRightChange: Function = (_index: number) => {
-  }
+  dialogRightChange: Function = (_index: number) => {}
   @State showFunction: boolean = false
+  flexAlign?: FlexAlign = FlexAlign.SpaceBetween
+  // 右侧按钮图标
+  rightIcon?: PixelMap | ResourceStr | DrawableDescriptor
 
   build() {
     Column() {
       // 顶部固定内容
       Row() {
-        Column() {
-          Image($r("app.media.return_left"))
-            .size({ width: 24, height: 24 })
-            .interpolation(ImageInterpolation.Medium)
-            .onClick(() => {
-              router.back()
-            })
+        if (this.customLeftBuilder !== this.leftBuilder) {
+          this.customLeftBuilder()
+        } else {
+          Column() {
+            Image($r("app.media.return_left"))
+              .size({ width: 24, height: 24 })
+              .interpolation(ImageInterpolation.Medium)
+              .onClick(() => {
+                router.back()
+              })
+          }
+          .alignItems(HorizontalAlign.Start)
         }
-        .alignItems(HorizontalAlign.Start)
 
-
-        if (this.title) {
+        if (this.customTitleBuilder !== this.titleBuilder) {
+          this.customTitleBuilder()
+        } else {
           Column() {
             Text(this.title)
               .lineHeight(24)
@@ -42,12 +64,13 @@ export default struct Header {
               })
           }
         }
-        if (this.customTitleBuilder) {
-          this.customTitleBuilder()
+
+        if (this.customRightBuilder !== this.rightBuilder) {
+          this.customRightBuilder()
         }
 
         if (this.dialogRightData.length) {
-          Image($r('app.media.addSubscription')).width(24)
+          Image(this.rightIcon ? this.rightIcon : $r('app.media.addSubscription')).width(24)
             .bindMenu(
               this.showFunction,
               this.dialogRightFuction(),
@@ -60,11 +83,13 @@ export default struct Header {
               this.showFunction = true
             })
         } else {
-          Row()
-            .size({ width: 24, height: 24 })
+          if (this.customRightBuilder === this.rightBuilder && !this.dialogRightData.length) {
+            Row()
+              .size({ width: 24 })
+          }
         }
       }
-      .justifyContent(FlexAlign.SpaceBetween)
+      .justifyContent(this.flexAlign)
       .padding({
         left: 12,
         right: 20,
@@ -75,7 +100,7 @@ export default struct Header {
       .width("100%")
     }
     .padding({
-      top: this.topRectHeight
+      top: this.topRectHeight + this.paddingTop
     })
   }
 

--- a/entry/src/main/ets/componets/import/ImportCommon.ets
+++ b/entry/src/main/ets/componets/import/ImportCommon.ets
@@ -4,6 +4,7 @@
  * @className: ImportCommon
  * 通用导入页
  */
+import ClassifyList from '../common/ClassifyList';
 import Score from '../common/Score';
 import Tag from '../common/Tag';
 import { BookSource, GroupList } from '../dataList/BookSource';
@@ -59,51 +60,15 @@ export default struct ImportCommon {
   build() {
     Column() {
       Row({ space: 12 }) {
-        List({ scroller: this.scroll }) {
-          ForEach(this.groupList, (item: GroupList, index: number) => {
-            ListItem() {
-              Stack({ alignContent: Alignment.TopStart }) {
-                Column() {
-                  Text(item.title)
-                    .width('100vp')
-                    .height('48vp')
-                    .textAlign(TextAlign.Center)
-                    .fontWeight(this.currentIndex === index ? FontWeight.Bold : FontWeight.Normal)
-                }
-                .backgroundColor(this.currentIndex === index ? 0xF5F5F5 : Color.White)
-                .borderRadius({
-                  topRight: this.currentIndex + 1 === index ? 12 : 0,
-                  bottomRight: this.currentIndex - 1 === index || this.groupList.length === index + 1 ? 12 : 0
-                })
-                .animation({
-                  duration: 100,
-                  curve: Curve.Linear
-                })
-                .onClick(() => {
-                  this.scrollChangeAction(index, true)
-                })
-
-                if (this.currentIndex === index) {
-                  Row()
-                    .width(3)
-                    .height(16)
-                    .backgroundColor('#FF6600')
-                    .borderRadius(12)
-                    .position({
-                      top: 16
-                    })
-                }
-              }
-            }
-          })
-        }
-        .height('100%')
-        .width(88)
-        .scrollBar(BarState.Off)
-        .borderRadius({
-          topRight: 12,
-          bottomRight: 12
+        ClassifyList({
+          currentIndex: this.currentIndex,
+          classifyList: this.groupList.map(o => o.title),
+          scroller: this.scroll,
+          clickAction: (index: number) => {
+            this.scrollChangeAction(index, true)
+          }
         })
+          .width(88)
 
         List({ scroller: this.secondScroll }) {
           ForEach(this.groupList, (item: GroupList, index: number) => {

--- a/entry/src/main/ets/pages/view/Find/BookSource/SourceView.ets
+++ b/entry/src/main/ets/pages/view/Find/BookSource/SourceView.ets
@@ -1,4 +1,5 @@
 import axios, { AxiosError, AxiosResponse } from '@ohos/axios'
+import ClassifyList from '../../../../componets/common/ClassifyList'
 import { showMessage } from '../../../../componets/common/promptShow'
 import Score from '../../../../componets/common/Score'
 import Tag from '../../../../componets/common/Tag'
@@ -101,69 +102,16 @@ export default struct SourceView {
 
         // 内容主体
         Row({ space: 12 }) {
-          List({ scroller: this.scroll }) {
-            ForEach(this.groupList, (item: GroupList, index: number) => {
-              ListItem() {
-                Stack({ alignContent: Alignment.TopStart }) {
-                  Column() {
-                    Stack({ alignContent: Alignment.TopEnd }) {
-                      Text(item.title)
-                        .height('48vp')
-                        .textAlign(TextAlign.Center)
-                        .fontWeight(this.currentIndex === index ? FontWeight.Bold : FontWeight.Normal)
-                      Column() {
-                        Text('12')
-                          .fontSize(10)
-                          .fontWeight(500)
-                          .fontColor(Color.White)
-                          .textAlign(TextAlign.Center)
-                      }
-                      .height(16)
-                      .position({
-                        right: -10
-                      })
-                      .justifyContent(FlexAlign.Center)
-                      .padding({ left: 4, right: 4 })
-                      .borderRadius(20)
-                      .backgroundColor(0xEF4444)
-                    }
-                  }
-                  .width('100%')
-                  .alignItems(HorizontalAlign.Center)
-                  .backgroundColor(this.currentIndex === index ? 0xF5F5F5 : Color.White)
-                  .borderRadius({
-                    topRight: this.currentIndex + 1 === index ? 12 : 0,
-                    bottomRight: this.currentIndex - 1 === index || this.groupList.length === index + 1 ? 12 : 0
-                  })
-                  .animation({
-                    duration: 100,
-                    curve: Curve.Linear
-                  })
-                  .onClick(() => {
-                    this.scrollChangeAction(index, true)
-                  })
-
-                  if (this.currentIndex === index) {
-                    Row()
-                      .width(3)
-                      .height(16)
-                      .backgroundColor('#FF6600')
-                      .borderRadius(12)
-                      .position({
-                        top: 16
-                      })
-                  }
-                }
-              }
-            })
-          }
-          .height('100%')
-          .width(88)
-          .scrollBar(BarState.Off)
-          .borderRadius({
-            topRight: 12,
-            bottomRight: 12
+          ClassifyList({
+            currentIndex: this.currentIndex,
+            classifyList: this.groupList,
+            scroller: this.scroll,
+            clickAction: (index: number) => {
+              this.scrollChangeAction(index, true)
+            },
+            isBadge: true
           })
+            .width(88)
 
           List({ scroller: this.secondScroll }) {
             ForEach(this.groupList, (item: GroupList, index: number) => {
@@ -239,6 +187,7 @@ export default struct SourceView {
 
       Blank()
     }
+    .width('100%')
     .padding({ right: 16 })
     .backgroundColor('#f5f5f5')
     .justifyContent(FlexAlign.Start)


### PR DESCRIPTION
分类左侧列表抽离为公共组件，完善Header公共组件，使其适配所有页面场景，简单传个标题和右侧下拉列表即可完善页面头部功能